### PR TITLE
Updated Cupertino Icons dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  # cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updating Cupertino Icons dependency to the latest. 
FYI: I didn't find where this dependency was being used if it's not used anymore could you please remove it and update the package at https://pub.dev as well? Thank you!